### PR TITLE
[WIP] Windows Support

### DIFF
--- a/esy/build.sh
+++ b/esy/build.sh
@@ -1,0 +1,4 @@
+find ./ -exec touch -t 200905000000 {} \\;
+./configure --with-internal-glib --prefix $cur__install
+make
+make install

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
       [
         "bash",
         "-c",
-        "which pkg-config || (find ./ -exec touch -t 200905000000 {} \\; && ./configure --with-internal-glib --prefix $cur__install && make && make install)"
+        "which pkg-config || (./esy/build.sh)"
       ]
     ],
     "exportedEnv": {
@@ -15,7 +15,7 @@
         "val": "/usr/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/share/pkgconfig:/usr/local/share/pkgconfig:$cur__lib:$PKG_CONFIG_PATH"
       }
     },
-    "buildsInSource": true
+    "buildsInSource": "_build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Factor out the shell commands from inline in the package.json to a separate script.

This fixes the initial error here: https://github.com/esy/esy/issues/420

But still more errors after, like:
```
checking for iconv_open... no                                                                                          
checking for libiconv_open in -liconv... no                                                                            
checking for iconv_open in -liconv... no                                                                               
configure: error: *** No iconv() implementation found in C library or libiconv                                         
configure: error: ./configure failed for glib                                                                          
```

Cygwin shows `libiconv` as being installed, but it's not available to this configure script. Next step is to figure out why it's not being found (or figure out if we should build it from sources outside of cygwin).