### PR TITLE
Fixes libwinpthread-1.dll not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
        ]
     ],
     "exportedEnv": {
+      "PATH": {
+        "scope": "global",
+        "val": "#{'/usr/x86_64-w64-mingw32/sys-root/mingw/bin': $PATH}"
+      },
       "PKG_CONFIG_PATH": {
         "scope": "global",
         "val": "#{'/usr/lib/pkgconfig':'/usr/local/lib/pkgconfig':'/usr/share/pkgconfig':'/usr/local/share/pkgconfig':$cur__lib:$PKG_CONFIG_PATH}"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "exportedEnv": {
       "PATH": {
         "scope": "global",
-        "val": "#{'/usr/x86_64-w64-mingw32/sys-root/mingw/bin': $PATH}"
+        "val": "#{ (os == 'windows' ? '/usr/x86_64-w64-mingw32/sys-root/mingw/bin': '') : $PATH}"
       },
       "PKG_CONFIG_PATH": {
         "scope": "global",


### PR DESCRIPTION
On Cygwin, libwinpthread-1.dll is found in `/usr/x86_64-w64-mingw32/sys-root/mingw/bin` Appending it to the exported path helps find the DLL