### PR TITLE
Install pkg-config on all platforms

### DIFF
--- a/glib/glib/gdate.c
+++ b/glib/glib/gdate.c
@@ -2494,7 +2494,11 @@ g_date_strftime (gchar       *s,
        * recognize whether strftime actually failed or just returned "".
        */
       tmpbuf[0] = '\1';
+
+      #pragma GCC diagnostic push
+      #pragma GCC diagnostic ignored "-Wformat-nonliteral"
       tmplen = strftime (tmpbuf, tmpbufsize, locale_format, &tm);
+      #pragma GCC diagnostic pop
 
       if (tmplen == 0 && tmpbuf[0] != '\0')
         {

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "0.29.5",
   "esy": {
     "build": [
+      "find ./ -exec touch -t 200905010101 {} +",
       [
          "bash",
          "-c",
-        "which pkg-config || (find ./ -exec touch -t 200905010101 {} + && ./configure --with-internal-glib --prefix $cur__install #{os == 'windows' ? '--host x86_64-w64-mingw32' : ''} && make && make install)"
-       ]
+        "./configure --with-internal-glib --prefix $cur__install #{os == 'windows' ? '--host x86_64-w64-mingw32' : ''}"
+      ],
+      "make",
+      "make install"
     ],
     "exportedEnv": {
       "PATH": {


### PR DESCRIPTION
We had a issue on Windows where @bryphe already had pkg-config in his cygwin but I did not. Preinstalled pkg-config could not query the library inside cmd.exe. `yarn-pkg-config` works great however.

This PR ensure `yarn-pkg-config` installs regardless of whether the system already has it. Helps our reproducible setup cause too 🙂 