### PR TITLE
package.json: Add location to PKG_CONFIG_PATH

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       },
       "PKG_CONFIG_PATH": {
         "scope": "global",
-        "val": "#{'/usr/lib/pkgconfig':'/usr/local/lib/pkgconfig':'/usr/share/pkgconfig':'/usr/local/share/pkgconfig':$cur__lib:$PKG_CONFIG_PATH}"
+        "val": "#{'/usr/lib/x86_64-linux-gnu/pkgconfig':'/usr/lib/pkgconfig':'/usr/local/lib/pkgconfig':'/usr/share/pkgconfig':'/usr/local/share/pkgconfig':$cur__lib:$PKG_CONFIG_PATH}"
       }
     },
     "buildsInSource": true


### PR DESCRIPTION
Ubuntu in particular stores most of its .pc files (used by pkg-config) in this location. This shouldn't hurt on systems that don't have this location.